### PR TITLE
Hacks to get around issue #3.

### DIFF
--- a/launch/kinect2_bridge_loki.launch
+++ b/launch/kinect2_bridge_loki.launch
@@ -2,16 +2,14 @@
 
     <!--<machine name="loki.local" address="loki.local"/>-->
 
-    <include file="$(find kinect2_bridge)/launch/kinect2_bridge.launch">
-        <arg name="sensor"          value="000792364047"/>
+    <include file="$(find kinect2_calibration_files)/launch/kinect2_respawn_hack_step1.launch">
         <arg name="base_name"       value="kinect2_victor_head"/>
         <arg name="publish_tf"      value="true"/>
-        <arg name="fps_limit"       value="30"/>
-        <arg name="calib_path"      value="$(find kinect2_calibration_files)/data"/>
-        <arg name="depth_method"    value="cuda"/>
-        <arg name="reg_method"      value="opencl"/>
-        <arg name="queue_size"      value="2"/>
-        <arg name="worker_threads"  value="4"/>
+        <arg name="fps_limit"       value="10"/>
+        <!--<arg name="depth_method"    value="cuda"/>-->
+        <!--<arg name="reg_method"      value="opencl"/>-->
+        <!--<arg name="queue_size"      value="2"/>-->
+        <!--<arg name="worker_threads"  value="4"/>-->
         <!--<arg name="machine"         value="loki.local"/>-->
         <!--<arg name="use_machine"     value="true"/>-->
     </include>

--- a/launch/kinect2_bridge_thor.launch
+++ b/launch/kinect2_bridge_thor.launch
@@ -2,15 +2,14 @@
 
     <!--<machine name="thor.local" address="thor.local"/>-->
 
-    <include file="$(find kinect2_bridge)/launch/kinect2_bridge.launch">
+    <include file="$(find kinect2_calibration_files)/launch/kinect2_respawn_hack_step1.launch">
         <arg name="base_name"       value="kinect2_roof"/>
         <arg name="publish_tf"      value="true"/>
-        <arg name="fps_limit"       value="30"/>
-        <arg name="calib_path"      value="$(find kinect2_calibration_files)/data"/>
-        <!--arg name="depth_method"    value="opencl"/-->
-        <!--arg name="reg_method"      value="cpu"/-->
-        <!--arg name="queue_size"      value="5"/-->
-        <!--arg name="worker_threads"  value="4"/-->
+        <arg name="fps_limit"       value="10"/>
+        <!--<arg name="depth_method"    value="cuda"/>-->
+        <!--<arg name="reg_method"      value="opencl"/>-->
+        <!--<arg name="queue_size"      value="5"/>-->
+        <!--<arg name="worker_threads"  value="4"/>-->
         <!--<arg name="machine"         value="thor.local"/>-->
         <!--<arg name="use_machine"     value="true"/>-->
     </include>

--- a/launch/kinect2_respawn_hack_step1.launch
+++ b/launch/kinect2_respawn_hack_step1.launch
@@ -1,0 +1,14 @@
+<launch>
+    <arg name="base_name"         default="kinect2"/>
+    <arg name="publish_tf"        default="false"/>
+    <arg name="fps_limit"         default="-1.0"/>
+
+    <!-- This script assumes exactly 3 arguments, if that ever changes this and "rerun_kinect_launch_file" must change in sync-->
+    <node pkg="kinect2_calibration_files"
+          type="kinect2_respawn_hack_step2.sh"
+          name="$(anon kinect2_bridge_respawner)"
+          args="base_name:=$(arg base_name)
+                publish_tf:=$(arg publish_tf)
+                fps_limit:=$(arg fps_limit)">
+    </node>
+</launch>

--- a/launch/kinect2_respawn_hack_step4.launch
+++ b/launch/kinect2_respawn_hack_step4.launch
@@ -1,0 +1,87 @@
+<launch>
+
+  <arg name="base_name"         default="kinect2"/>
+  <arg name="sensor"            default=""/>
+  <arg name="publish_tf"        default="false"/>
+  <arg name="base_name_tf"      default="$(arg base_name)"/>
+  <arg name="fps_limit"         default="-1.0"/>
+  <arg name="calib_path"        default="$(find kinect2_calibration_files)/data/"/>
+  <arg name="use_png"           default="false"/>
+  <arg name="jpeg_quality"      default="90"/>
+  <arg name="png_level"         default="1"/>
+  <arg name="depth_method"      default="default"/>
+  <arg name="depth_device"      default="-1"/>
+  <arg name="reg_method"        default="default"/>
+  <arg name="reg_device"        default="-1"/>
+  <arg name="max_depth"         default="12.0"/>
+  <arg name="min_depth"         default="0.1"/>
+  <arg name="queue_size"        default="5"/>
+  <arg name="bilateral_filter"  default="true"/>
+  <arg name="edge_aware_filter" default="true"/>
+  <arg name="worker_threads"    default="4"/>
+  <arg name="machine"           default="localhost"/>
+  <arg name="nodelet_manager"   default="$(arg base_name)"/>
+  <arg name="start_manager"     default="true"/>
+  <arg name="use_machine"       default="true"/>
+  <arg name="output"            default="screen"/>
+
+  <machine name="localhost" address="localhost" if="$(arg use_machine)"/>
+
+  <node pkg="nodelet" type="nodelet" name="$(arg nodelet_manager)" args="manager"
+        if="$(arg start_manager)" machine="$(arg machine)" output="screen" required="true"/>
+
+  <!-- Nodelet version of kinect2_bridge -->
+  <node pkg="nodelet" type="nodelet" name="$(arg base_name)_bridge" machine="$(arg machine)"
+        args="load kinect2_bridge/kinect2_bridge_nodelet $(arg nodelet_manager)"
+        output="$(arg output)" required="true">
+    <param name="base_name"         type="str"    value="$(arg base_name)"/>
+    <param name="sensor"            type="str"    value="$(arg sensor)"/>
+    <param name="publish_tf"        type="bool"   value="$(arg publish_tf)"/>
+    <param name="base_name_tf"      type="str"    value="$(arg base_name_tf)"/>
+    <param name="fps_limit"         type="double" value="$(arg fps_limit)"/>
+    <param name="calib_path"        type="str"    value="$(arg calib_path)"/>
+    <param name="use_png"           type="bool"   value="$(arg use_png)"/>
+    <param name="jpeg_quality"      type="int"    value="$(arg jpeg_quality)"/>
+    <param name="png_level"         type="int"    value="$(arg png_level)"/>
+    <param name="depth_method"      type="str"    value="$(arg depth_method)"/>
+    <param name="depth_device"      type="int"    value="$(arg depth_device)"/>
+    <param name="reg_method"        type="str"    value="$(arg reg_method)"/>
+    <param name="reg_device"        type="int"    value="$(arg reg_device)"/>
+    <param name="max_depth"         type="double" value="$(arg max_depth)"/>
+    <param name="min_depth"         type="double" value="$(arg min_depth)"/>
+    <param name="queue_size"        type="int"    value="$(arg queue_size)"/>
+    <param name="bilateral_filter"  type="bool"   value="$(arg bilateral_filter)"/>
+    <param name="edge_aware_filter" type="bool"   value="$(arg edge_aware_filter)"/>
+    <param name="worker_threads"    type="int"    value="$(arg worker_threads)"/>
+  </node>
+
+  <!-- sd point cloud (512 x 424) -->
+  <node pkg="nodelet" type="nodelet" name="$(arg base_name)_points_xyzrgb_sd" machine="$(arg machine)"
+        args="load depth_image_proc/point_cloud_xyzrgb $(arg nodelet_manager)">
+    <remap from="rgb/camera_info"             to="$(arg base_name)/sd/camera_info"/>
+    <remap from="rgb/image_rect_color"        to="$(arg base_name)/sd/image_color_rect"/>
+    <remap from="depth_registered/image_rect" to="$(arg base_name)/sd/image_depth_rect"/>
+    <remap from="depth_registered/points"     to="$(arg base_name)/sd/points"/>
+    <param name="queue_size" type="int" value="$(arg queue_size)"/>
+  </node>
+
+  <!-- qhd point cloud (960 x 540) -->
+  <node pkg="nodelet" type="nodelet" name="$(arg base_name)_points_xyzrgb_qhd" machine="$(arg machine)"
+        args="load depth_image_proc/point_cloud_xyzrgb $(arg nodelet_manager)">
+    <remap from="rgb/camera_info"             to="$(arg base_name)/qhd/camera_info"/>
+    <remap from="rgb/image_rect_color"        to="$(arg base_name)/qhd/image_color_rect"/>
+    <remap from="depth_registered/image_rect" to="$(arg base_name)/qhd/image_depth_rect"/>
+    <remap from="depth_registered/points"     to="$(arg base_name)/qhd/points"/>
+    <param name="queue_size" type="int" value="$(arg queue_size)"/>
+  </node>
+
+  <!-- hd point cloud (1920 x 1080) -->
+  <node pkg="nodelet" type="nodelet" name="$(arg base_name)_points_xyzrgb_hd" machine="$(arg machine)"
+        args="load depth_image_proc/point_cloud_xyzrgb $(arg nodelet_manager)">
+    <remap from="rgb/camera_info"             to="$(arg base_name)/hd/camera_info"/>
+    <remap from="rgb/image_rect_color"        to="$(arg base_name)/hd/image_color_rect"/>
+    <remap from="depth_registered/image_rect" to="$(arg base_name)/hd/image_depth_rect"/>
+    <remap from="depth_registered/points"     to="$(arg base_name)/hd/points"/>
+    <param name="queue_size" type="int" value="$(arg queue_size)"/>
+  </node>
+</launch>

--- a/launch/mocap_to_kinect_static_transforms.launch
+++ b/launch/mocap_to_kinect_static_transforms.launch
@@ -26,14 +26,14 @@
 
     <!-- These values were tweaked to visually match better for the MPS project-->
     <node pkg="tf2_ros" type="static_transform_publisher" name="kinect2_roof_tf_broadcaster" required="true"
-          args="2.219   -0.327   1.993       -0.718    0.693   -0.047   0.038   mocap_world kinect2_roof_link">
+          args="2.219   -0.327   1.993       -0.71820615    0.69319898   -0.04701349   0.03801091   mocap_world kinect2_roof_link">
         <param name="use_sim_time" value="$(arg use_sim_time)"/>
     </node>
           <!--args="0.031008404506653   0.021057223721192  -0.030030148860467        0.499966532285212  -0.504136092343149   0.491916169558652  -0.503883666254844    /mocap_Kinect2BlockRoof_Kinect2BlockRoof   /kinect2_roof_link">-->
 
     <!-- Tweaked by hand for visually correct data, using qhd stream -->
     <node pkg="tf2_ros" type="static_transform_publisher" name="kinect2_victor_head_tf_broadcaster" required="true"
-          args="0.035   0.02   -0.03          0.515983100216175  -0.515983100216175   0.483488821268191  -0.483488821268191         mocap_Kinect2VictorHead_Kinect2VictorHead   /kinect2_victor_head_link">
+          args="0.035   0.02   -0.03          0.515983100216175  -0.515983100216175   0.483488821268191  -0.483488821268191         mocap_Kinect2VictorHead_Kinect2VictorHead   kinect2_victor_head_link">
         <param name="use_sim_time" value="$(arg use_sim_time)"/>
     </node>
 

--- a/scripts/kinect2_respawn_hack_step2.sh
+++ b/scripts/kinect2_respawn_hack_step2.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Assumes exactly 3 arguments, if that ever changes this and "kinect2_bridge_respawner.launch" must change in sync
+
+# roslaunch returns the same value regardless of the exit code of each node,
+# so for now just rely on a spammed Ctrl+C to close this script
+cd "$(dirname "$0")"
+until ./kinect2_respawn_hack_step3.sh ${1} ${2} ${3}; do
+    echo "rerun_helper.sh exited with code $?. Respawning.." >&2
+    sleep 1
+done
+
+echo "Final rerun_helper.sh output code $?." >&2

--- a/scripts/kinect2_respawn_hack_step3.sh
+++ b/scripts/kinect2_respawn_hack_step3.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+roslaunch kinect2_calibration_files kinect2_respawn_hack_step4.launch $@ 2> /tmp/Error
+ERROR=$(</tmp/Error)
+echo
+echo
+echo
+echo "Errors found while running:"
+echo "${ERROR}"
+
+# Check for a failure to launch a nodelet in the error logs
+if [[ ${ERROR} = *"Failed to load nodelet"* ]]; then
+  exit -1
+fi


### PR DESCRIPTION
This "solution" wraps roslaunch in a parsing script to watch for errors, forcing roslaunch to close and reopen as needed. On a clean run, all errors are caught by the wrapper, getting dumped at the end instead of interspersed with the STDOUT data.