### PR TITLE
[Bugfix] Prevent file permissions from interfeering

### DIFF
--- a/scripts/kinect2_respawn_hack_step3.sh
+++ b/scripts/kinect2_respawn_hack_step3.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 roslaunch kinect2_calibration_files kinect2_respawn_hack_step4.launch $@ 2> /tmp/Error
+chmod 666 /tmp/Error
 ERROR=$(</tmp/Error)
 echo
 echo


### PR DESCRIPTION
There is a bug where using different users to launch the kinect software can prevent the respawn hack from operating correctly due to file permissions. This addresses the file permissions.